### PR TITLE
Reduce resource consumption used to [un]marshal time.Time

### DIFF
--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -100,13 +100,23 @@ func validateTime(seconds int64, nanos int32) error {
 }
 
 func StdTimeMarshal(t time.Time) ([]byte, error) {
-	ts, err := TimestampProto(t)
-	if err != nil {
+	seconds := t.Unix()
+	nanos := int32(t.Nanosecond())
+
+	if err := validateTime(seconds, nanos); err != nil {
 		return nil, err
 	}
 
-	buf := make([]byte, ts.Size())
-	_, err = ts.MarshalTo(buf)
+	var n int
+	if seconds != 0 {
+		n += 1 + sovTimestamp(uint64(seconds))
+	}
+	if nanos != 0 {
+		n += 1 + sovTimestamp(uint64(nanos))
+	}
+
+	buf := make([]byte, n)
+	_, err := StdTimeMarshalTo(t, buf)
 	return buf, err
 }
 

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -29,6 +29,7 @@
 package types
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -82,6 +83,22 @@ func SizeOfStdTime(t time.Time) int {
 	return n
 }
 
+func validateTime(seconds int64, nanos int32) error {
+	if seconds < minValidSeconds {
+		t := time.Unix(seconds, int64(nanos)).UTC()
+		return fmt.Errorf("timestamp: %#v before 0001-01-01", t)
+	}
+	if seconds >= maxValidSeconds {
+		t := time.Unix(seconds, int64(nanos)).UTC()
+		return fmt.Errorf("timestamp: %#v after 10000-01-01", t)
+	}
+	if nanos < 0 || nanos >= 1e9 {
+		t := time.Unix(seconds, int64(nanos)).UTC()
+		return fmt.Errorf("timestamp: %#v: nanos not in range [0, 1e9)", t)
+	}
+	return nil
+}
+
 func StdTimeMarshal(t time.Time) ([]byte, error) {
 	ts, err := TimestampProto(t)
 	if err != nil {
@@ -94,11 +111,35 @@ func StdTimeMarshal(t time.Time) ([]byte, error) {
 }
 
 func StdTimeMarshalTo(t time.Time, data []byte) (int, error) {
-	ts, err := TimestampProto(t)
-	if err != nil {
+	seconds := t.Unix()
+	nanos := int32(t.Nanosecond())
+
+	if err := validateTime(seconds, nanos); err != nil {
 		return 0, err
 	}
-	return ts.MarshalTo(data)
+
+	var n int
+	if seconds != 0 {
+		n += 1 + sovTimestamp(uint64(seconds))
+	}
+	if nanos != 0 {
+		n += 1 + sovTimestamp(uint64(nanos))
+	}
+
+	dAtA := data[:n]
+	i := len(dAtA)
+
+	if nanos != 0 {
+		i = encodeVarintTimestamp(dAtA, i, uint64(nanos))
+		i--
+		dAtA[i] = 0x10
+	}
+	if seconds != 0 {
+		i = encodeVarintTimestamp(dAtA, i, uint64(seconds))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func StdTimeUnmarshal(t *time.Time, data []byte) error {

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -30,7 +30,7 @@ package types
 
 import (
 	"fmt"
-	io "io"
+	"io"
 	"time"
 )
 

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -58,17 +58,38 @@ func NewPopulatedStdTime(r interface {
 }
 
 func SizeOfStdTime(t time.Time) int {
-	ts, err := TimestampProto(t)
-	if err != nil {
+	seconds := t.Unix()
+	nanos := int32(t.Nanosecond())
+
+	if seconds < minValidSeconds {
 		return 0
 	}
-	return ts.Size()
+	if seconds >= maxValidSeconds {
+		return 0
+	}
+	if nanos < 0 || nanos >= 1e9 {
+		return 0
+	}
+
+	var n int
+	if seconds != 0 {
+		n += 1 + sovTimestamp(uint64(seconds))
+	}
+	if nanos != 0 {
+		n += 1 + sovTimestamp(uint64(nanos))
+	}
+
+	return n
 }
 
 func StdTimeMarshal(t time.Time) ([]byte, error) {
-	size := SizeOfStdTime(t)
-	buf := make([]byte, size)
-	_, err := StdTimeMarshalTo(t, buf)
+	ts, err := TimestampProto(t)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, ts.Size())
+	_, err = ts.MarshalTo(buf)
 	return buf, err
 }
 

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -30,6 +30,7 @@ package types
 
 import (
 	"fmt"
+	io "io"
 	"time"
 )
 
@@ -153,14 +154,95 @@ func StdTimeMarshalTo(t time.Time, data []byte) (int, error) {
 }
 
 func StdTimeUnmarshal(t *time.Time, data []byte) error {
-	ts := &Timestamp{}
-	if err := ts.Unmarshal(data); err != nil {
-		return err
+	var seconds int64
+	var nanos int32
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTimestamp
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Timestamp: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Timestamp: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Seconds", wireType)
+			}
+			seconds = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimestamp
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				seconds |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Nanos", wireType)
+			}
+			nanos = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTimestamp
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				nanos |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTimestamp(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTimestamp
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+
+			iNdEx += skippy
+		}
 	}
-	tt, err := TimestampFromProto(ts)
-	if err != nil {
-		return err
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
 	}
-	*t = tt
+
+	*t = time.Unix(seconds, int64(nanos)).UTC()
 	return nil
 }


### PR DESCRIPTION
This removes all allocations from marshaling and unmarshaling time.Time. The practical effects of this change can be seen from executing the BenchmarkListResourcesWithSort tests with and without this change..

```bash
 benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/cache
cpu: Apple M2 Pro
                                                      │   old.txt   │               new.txt               │
                                                      │   sec/op    │   sec/op     vs base                │
ListResourcesWithSort/limit=100,needTotal=true-12       1.794m ± 3%   1.457m ± 4%  -18.80% (p=0.000 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      1.799m ± 4%   1.458m ± 0%  -18.96% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      17.70m ± 0%   14.25m ± 3%  -19.47% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     17.66m ± 0%   14.26m ± 1%  -19.28% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     182.5m ± 1%   149.9m ± 0%  -17.87% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    182.9m ± 2%   149.2m ± 1%  -18.39% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12     1.815 ± 2%    1.448 ± 2%  -20.20% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12    1.811 ± 1%    1.468 ± 1%  -18.92% (p=0.000 n=10)
geomean                                                 56.95m        46.14m       -18.99%

                                                      │    old.txt    │                new.txt                │
                                                      │     B/op      │     B/op       vs base                │
ListResourcesWithSort/limit=100,needTotal=true-12       393.4Ki ±  0%   299.7Ki ±  0%  -23.83% (p=0.000 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      393.4Ki ± 38%   299.7Ki ±  0%  -23.83% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      3.792Mi ±  0%   2.876Mi ± 15%  -24.15% (p=0.001 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     3.792Mi ±  0%   2.876Mi ±  0%  -24.15% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     38.18Mi ±  0%   29.02Mi ±  0%  -23.98% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    38.18Mi ±  0%   29.02Mi ±  0%  -23.98% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12    383.9Mi ±  0%   292.3Mi ±  0%  -23.85% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12   383.9Mi ±  0%   292.3Mi ±  0%  -23.85% (p=0.001 n=10)
geomean                                                 12.09Mi         9.193Mi        -23.95%

                                                      │   old.txt    │               new.txt                │
                                                      │  allocs/op   │  allocs/op    vs base                │
ListResourcesWithSort/limit=100,needTotal=true-12       5.107k ±  0%   3.107k ±  0%  -39.16% (p=0.000 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      5.107k ± 38%   3.107k ±  0%  -39.16% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      50.11k ±  0%   30.11k ± 14%  -39.91% (p=0.001 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     50.11k ±  0%   30.11k ±  0%  -39.91% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     500.1k ±  0%   300.1k ±  0%  -39.99% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    500.1k ±  0%   300.1k ±  0%  -39.99% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12    5.000M ±  0%   3.000M ±  0%  -40.00% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12   5.000M ±  0%   3.000M ±  0%  -40.00% (p=0.001 n=10)
geomean                                                 159.1k         95.80k        -39.77%
```


![profile001](https://github.com/user-attachments/assets/03289cb8-2d08-41c0-b97f-69c10ce08766)
