### PR TITLE
Avoid allocations when handling timestamps

### DIFF
--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -63,13 +63,13 @@ func validateTimestamp(ts *Timestamp) error {
 		return errors.New("timestamp: nil Timestamp")
 	}
 	if ts.Seconds < minValidSeconds {
-		return fmt.Errorf("timestamp: %#v before 0001-01-01", ts)
+		return fmt.Errorf("timestamp: seconds %d before 0001-01-01", ts.Seconds)
 	}
 	if ts.Seconds >= maxValidSeconds {
-		return fmt.Errorf("timestamp: %#v after 10000-01-01", ts)
+		return fmt.Errorf("timestamp: seconds %d after 10000-01-01", ts.Seconds)
 	}
 	if ts.Nanos < 0 || ts.Nanos >= 1e9 {
-		return fmt.Errorf("timestamp: %#v: nanos not in range [0, 1e9)", ts)
+		return fmt.Errorf("timestamp: nanos %d not in range [0, 1e9)", ts.Nanos)
 	}
 	return nil
 }

--- a/types/timestamp_gogo.go
+++ b/types/timestamp_gogo.go
@@ -58,8 +58,11 @@ func NewPopulatedStdTime(r interface {
 }
 
 func SizeOfStdTime(t time.Time) int {
-	ts, err := TimestampProto(t)
-	if err != nil {
+	ts := &Timestamp{
+		Seconds: t.Unix(),
+		Nanos:   int32(t.Nanosecond()),
+	}
+	if err := validateTimestamp(ts); err != nil {
 		return 0
 	}
 	return ts.Size()
@@ -73,8 +76,11 @@ func StdTimeMarshal(t time.Time) ([]byte, error) {
 }
 
 func StdTimeMarshalTo(t time.Time, data []byte) (int, error) {
-	ts, err := TimestampProto(t)
-	if err != nil {
+	ts := &Timestamp{
+		Seconds: t.Unix(),
+		Nanos:   int32(t.Nanosecond()),
+	}
+	if err := validateTimestamp(ts); err != nil {
 		return 0, err
 	}
 	return ts.MarshalTo(data)
@@ -85,10 +91,9 @@ func StdTimeUnmarshal(t *time.Time, data []byte) error {
 	if err := ts.Unmarshal(data); err != nil {
 		return err
 	}
-	tt, err := TimestampFromProto(ts)
-	if err != nil {
+	if err := validateTimestamp(ts); err != nil {
 		return err
 	}
-	*t = tt
+	*t = time.Unix(ts.Seconds, int64(ts.Nanos)).UTC()
 	return nil
 }


### PR DESCRIPTION
Similar to #3 but with much fewer code inlining.

The `validateTimestamp` function unconditionally spilled the `*Timestamp` parameter passed to it as a result of passing it to `fmt.Errorf`; as a result, a lot of the manually written functions in `timestamp.go` and `timestamp_gogo.go` ended up inadvertently allocating.

In addition to preventing that (by just referring to the individual numbers triggering errors), this PR also adds minimal manual inlining to replace some simple `TimestampProto` invocations with code that's easier to analyze for heap escapes.