### PR TITLE
Avoid `Value.Addr` panic in `Clone` and `Merge`

### DIFF
--- a/proto/clone.go
+++ b/proto/clone.go
@@ -138,7 +138,7 @@ func mergeStruct(out, in reflect.Value) {
 // viaPtr indicates whether the values were indirected through a pointer (implying proto2).
 // prop is set if this is a struct field (it may be nil).
 func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
-	if in.Type() == protoMessageType || in.Addr().Type().Implements(protoMessageType) {
+	if in.Type() == protoMessageType || (in.CanAddr() && in.Addr().Type().Implements(protoMessageType)) {
 		if in.Kind() == reflect.Ptr {
 			if !in.IsNil() {
 				if out.IsNil() {


### PR DESCRIPTION
The change in b03c65ea87cdc3521ede29f62fe3ce239267c1bc lacks an additional check that's present in the gogo/protobuf#710 PR, which can lead to problems when merging non-addressable fields. This PR restores the additional check.