### PR TITLE
Prefer using MapRange over MapKeys

### DIFF
--- a/proto/clone.go
+++ b/proto/clone.go
@@ -179,19 +179,20 @@ func mergeAny(out, in reflect.Value, viaPtr bool, prop *Properties) {
 		}
 		// For maps with value types of *T or []byte we need to deep copy each value.
 		elemKind := in.Type().Elem().Kind()
-		for _, key := range in.MapKeys() {
+		iter := in.MapRange()
+		for iter.Next() {
 			var val reflect.Value
 			switch elemKind {
 			case reflect.Ptr:
 				val = reflect.New(in.Type().Elem().Elem())
-				mergeAny(val, in.MapIndex(key), false, nil)
+				mergeAny(val, iter.Key(), false, nil)
 			case reflect.Slice:
-				val = in.MapIndex(key)
+				val = iter.Value()
 				val = reflect.ValueOf(append([]byte{}, val.Bytes()...))
 			default:
-				val = in.MapIndex(key)
+				val = iter.Value()
 			}
-			out.SetMapIndex(key, val)
+			out.SetMapIndex(iter.Key(), val)
 		}
 	case reflect.Ptr:
 		if in.IsNil() {

--- a/proto/discard.go
+++ b/proto/discard.go
@@ -204,8 +204,9 @@ func (di *discardInfo) computeDiscardInfo() {
 						if sm.Len() == 0 {
 							return
 						}
-						for _, key := range sm.MapKeys() {
-							val := sm.MapIndex(key)
+						iter := sm.MapRange()
+						for iter.Next() {
+							val := iter.Value()
 							DiscardUnknown(val.Interface().(Message))
 						}
 					}
@@ -303,8 +304,9 @@ func discardLegacy(m Message) {
 			default: // E.g., map[K]V
 				tv := vf.Type().Elem()
 				if tv.Kind() == reflect.Ptr && tv.Implements(protoMessageType) { // Proto struct (e.g., *T)
-					for _, key := range vf.MapKeys() {
-						val := vf.MapIndex(key)
+					iter := vf.MapRange()
+					for iter.Next() {
+						val := iter.Value()
 						discardLegacy(val.Interface().(Message))
 					}
 				}

--- a/proto/equal.go
+++ b/proto/equal.go
@@ -170,13 +170,14 @@ func equalAny(v1, v2 reflect.Value, prop *Properties) bool {
 		if v1.Len() != v2.Len() {
 			return false
 		}
-		for _, key := range v1.MapKeys() {
-			val2 := v2.MapIndex(key)
+		iter := v1.MapRange()
+		for iter.Next() {
+			val2 := iter.Value()
 			if !val2.IsValid() {
 				// This key was not found in the second map.
 				return false
 			}
-			if !equalAny(v1.MapIndex(key), val2, nil) {
+			if !equalAny(v1.MapIndex(iter.Key()), val2, nil) {
 				return false
 			}
 		}

--- a/proto/lib.go
+++ b/proto/lib.go
@@ -39,35 +39,35 @@ for a protocol buffer variable v:
 
   - Names are turned from camel_case to CamelCase for export.
   - There are no methods on v to set fields; just treat
-	them as structure fields.
+    them as structure fields.
   - There are getters that return a field's value if set,
-	and return the field's default value if unset.
-	The getters work even if the receiver is a nil message.
+    and return the field's default value if unset.
+    The getters work even if the receiver is a nil message.
   - The zero value for a struct is its correct initialization state.
-	All desired fields must be set before marshaling.
+    All desired fields must be set before marshaling.
   - A Reset() method will restore a protobuf struct to its zero state.
   - Non-repeated fields are pointers to the values; nil means unset.
-	That is, optional or required field int32 f becomes F *int32.
+    That is, optional or required field int32 f becomes F *int32.
   - Repeated fields are slices.
   - Helper functions are available to aid the setting of fields.
-	msg.Foo = proto.String("hello") // set field
+    msg.Foo = proto.String("hello") // set field
   - Constants are defined to hold the default values of all fields that
-	have them.  They have the form Default_StructName_FieldName.
-	Because the getter methods handle defaulted values,
-	direct use of these constants should be rare.
+    have them.  They have the form Default_StructName_FieldName.
+    Because the getter methods handle defaulted values,
+    direct use of these constants should be rare.
   - Enums are given type names and maps from names to values.
-	Enum values are prefixed by the enclosing message's name, or by the
-	enum's type name if it is a top-level enum. Enum types have a String
-	method, and a Enum method to assist in message construction.
+    Enum values are prefixed by the enclosing message's name, or by the
+    enum's type name if it is a top-level enum. Enum types have a String
+    method, and a Enum method to assist in message construction.
   - Nested messages, groups and enums have type names prefixed with the name of
-	the surrounding message type.
+    the surrounding message type.
   - Extensions are given descriptor names that start with E_,
-	followed by an underscore-delimited list of the nested messages
-	that contain it (if any) followed by the CamelCased name of the
-	extension field itself.  HasExtension, ClearExtension, GetExtension
-	and SetExtension are functions for manipulating extensions.
+    followed by an underscore-delimited list of the nested messages
+    that contain it (if any) followed by the CamelCased name of the
+    extension field itself.  HasExtension, ClearExtension, GetExtension
+    and SetExtension are functions for manipulating extensions.
   - Oneof field sets are given a single field in their message,
-	with distinguished wrapper types for each possible field value.
+    with distinguished wrapper types for each possible field value.
   - Marshal and Unmarshal are functions to encode and decode the wire format.
 
 When the .proto file specifies `syntax="proto3"`, there are some differences:
@@ -735,8 +735,9 @@ func setDefaults(v reflect.Value, recur, zeros bool) {
 			}
 
 		case reflect.Map:
-			for _, k := range f.MapKeys() {
-				e := f.MapIndex(k)
+			iter := f.MapRange()
+			for iter.Next() {
+				e := iter.Value()
 				if e.IsNil() {
 					continue
 				}

--- a/proto/table_marshal.go
+++ b/proto/table_marshal.go
@@ -2541,9 +2541,10 @@ func makeMapMarshaler(f *reflect.StructField) (sizer, marshaler) {
 	return func(ptr pointer, tagsize int) int {
 			m := ptr.asPointerTo(t).Elem() // the map
 			n := 0
-			for _, k := range m.MapKeys() {
-				ki := k.Interface()
-				vi := m.MapIndex(k).Interface()
+			iter := m.MapRange()
+			for iter.Next() {
+				ki := iter.Key().Interface()
+				vi := iter.Value().Interface()
 				kaddr := toAddrPointer(&ki, false)             // pointer to key
 				vaddr := toAddrPointer(&vi, valIsPtr)          // pointer to value
 				siz := keySizer(kaddr, 1) + valSizer(vaddr, 1) // tag of key = 1 (size=1), tag of val = 2 (size=1)

--- a/proto/table_merge.go
+++ b/proto/table_merge.go
@@ -600,26 +600,28 @@ func (mi *mergeInfo) computeMergeInfo() {
 					}
 					dm := dst.asPointerTo(tf).Elem()
 					if dm.IsNil() {
-						dm.Set(reflect.MakeMap(tf))
+						dm.Set(reflect.MakeMapWithSize(tf, sm.Len()))
 					}
 
 					switch tf.Elem().Kind() {
 					case reflect.Ptr: // Proto struct (e.g., *T)
-						for _, key := range sm.MapKeys() {
-							val := sm.MapIndex(key)
+						iter := sm.MapRange()
+						for iter.Next() {
+							val := iter.Value()
 							val = reflect.ValueOf(Clone(val.Interface().(Message)))
-							dm.SetMapIndex(key, val)
+							dm.SetMapIndex(iter.Key(), iter.Value())
 						}
 					case reflect.Slice: // E.g. Bytes type (e.g., []byte)
-						for _, key := range sm.MapKeys() {
-							val := sm.MapIndex(key)
+						iter := sm.MapRange()
+						for iter.Next() {
+							val := iter.Value()
 							val = reflect.ValueOf(append([]byte{}, val.Bytes()...))
-							dm.SetMapIndex(key, val)
+							dm.SetMapIndex(iter.Key(), val)
 						}
 					default: // Basic type (e.g., string)
-						for _, key := range sm.MapKeys() {
-							val := sm.MapIndex(key)
-							dm.SetMapIndex(key, val)
+						iter := sm.MapRange()
+						for iter.Next() {
+							dm.SetMapIndex(iter.Key(), iter.Value())
 						}
 					}
 				}


### PR DESCRIPTION
Converts all places that do not operate on a sorted map to use reflect.Value.MapRange to iterate over a map in order to reduce the number of allocations.

The was noticed when analyzing flame graphs from `BenchmarkListResourcesWithSort`. 


### Before

![image](https://github.com/user-attachments/assets/6e0788aa-ac02-4639-8d82-5add13f9ffbb)

### After

![image (2)](https://github.com/user-attachments/assets/8f686239-ae1f-4725-bf01-3040a0553199)


### Diff

```
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/cache
cpu: Apple M2 Pro
                                                      │   old.txt   │              new.txt              │
                                                      │   sec/op    │   sec/op     vs base               │
ListResourcesWithSort/limit=100,needTotal=true-12       2.031m ± 2%   1.936m ± 5%  -4.67% (p=0.015 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      2.019m ± 1%   1.952m ± 3%  -3.30% (p=0.005 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      18.87m ± 1%   18.02m ± 6%  -4.50% (p=0.023 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     18.85m ± 5%   18.52m ± 4%  -1.77% (p=0.007 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     195.2m ± 2%   186.5m ± 3%  -4.47% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    192.8m ± 1%   185.4m ± 6%       ~ (p=0.075 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12     1.897 ± 2%    1.886 ± 2%  -0.58% (p=0.019 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12    1.912 ± 4%    1.867 ± 5%       ~ (p=0.218 n=10)
geomean                                                 61.29m        59.33m       -3.19%

                                                      │   old.txt    │               new.txt               │
                                                      │     B/op     │     B/op       vs base               │
ListResourcesWithSort/limit=100,needTotal=true-12       249.6Ki ± 0%   235.5Ki ±  0%  -5.63% (p=0.000 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      249.6Ki ± 0%   235.5Ki ±  0%  -5.63% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      2.388Mi ± 0%   2.251Mi ± 57%  -5.75% (p=0.014 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     2.388Mi ± 0%   2.251Mi ±  0%  -5.75% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     24.14Mi ± 0%   22.77Mi ±  0%  -5.69% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    24.14Mi ± 0%   22.77Mi ±  0%  -5.69% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12    243.5Mi ± 0%   229.8Mi ±  0%  -5.64% (p=0.001 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12   243.5Mi ± 0%   229.8Mi ±  0%  -5.64% (p=0.001 n=10)
geomean                                                 7.648Mi        7.214Mi        -5.68%

                                                      │   old.txt   │              new.txt               │
                                                      │  allocs/op  │  allocs/op    vs base               │
ListResourcesWithSort/limit=100,needTotal=true-12       2.210k ± 0%   2.010k ±  0%  -9.05% (p=0.000 n=10)
ListResourcesWithSort/limit=100,needTotal=false-12      2.210k ± 0%   2.010k ±  0%  -9.05% (p=0.000 n=10)
ListResourcesWithSort/limit=1000,needTotal=true-12      21.11k ± 0%   19.11k ± 51%  -9.47% (p=0.008 n=10)
ListResourcesWithSort/limit=1000,needTotal=false-12     21.11k ± 0%   19.11k ±  0%  -9.47% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=true-12     210.1k ± 0%   190.1k ±  0%  -9.52% (p=0.000 n=10)
ListResourcesWithSort/limit=10000,needTotal=false-12    210.1k ± 0%   190.1k ±  0%  -9.52% (p=0.000 n=10)
ListResourcesWithSort/limit=100000,needTotal=true-12    2.100M ± 0%   1.900M ±  0%  -9.52% (p=0.001 n=10)
ListResourcesWithSort/limit=100000,needTotal=false-12   2.100M ± 0%   1.900M ±  0%  -9.52% (p=0.000 n=10)
geomean                                                 67.36k        61.04k        -9.39%
```
